### PR TITLE
Combine build and rm RUN commands into one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ VOLUME /data /certs
 COPY . /build
 COPY certs /certs
 
-RUN cd /build && ./mvnw -B package
-
-RUN cp /build/target/mccy-swarm-*.jar /usr/local/bin/mccy-swarm.jar && rm -rf /build && rm -rf $HOME/.m2
+RUN cd /build && ./mvnw -B package \
+  && cp /build/target/mccy-swarm-*.jar /usr/local/bin/mccy-swarm.jar \
+  && rm -rf /build $HOME/.m2 
 RUN ls -l /usr/local/bin/mccy-swarm.jar /certs
 WORKDIR /data
 


### PR DESCRIPTION
This allows the dockerfile to build on smaller docker hosts or ones with older dockers as there are fewer and smaller intermediates
